### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Dunkerque
- un
+
+This repository contains a simple Python GUI built with Tkinter for
+interacting with a Redis backend. The GUI script, `GUI.py`, can be used to
+send dragon-related data to a selected Redis instance for testing purposes.


### PR DESCRIPTION
## Summary
- remove stray word from README
- expand README with a short description of the repo

## Testing
- `python -m py_compile GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68401676d57c8322b092adf8976caa58